### PR TITLE
Add end() method

### DIFF
--- a/HL1606stripPWM.cpp
+++ b/HL1606stripPWM.cpp
@@ -54,6 +54,16 @@ void HL1606stripPWM::begin(void) {
 #endif
 }
 
+void HL1606stripPWM::end(void) {
+#if defined(__AVR_ATmega32U4__) 
+    TIMSK3 = (0 << OCIE3A);
+#else
+    TIMSK2 = (0 << OCIE2A);
+#endif
+
+    SPCR = _spcr;
+}
+
 
 void HL1606stripPWM::timerinit(void) {
   // calculate how long it will take to pulse one strip down
@@ -145,6 +155,7 @@ void HL1606stripPWM::SPIinit(void) {
   // set up high speed SPI for 500 KHz
   // The datasheet says that the clock pulse width must be > 300ns. Two pulses > 600ns that would
   // make the max frequency 1.6 MHz - fat chance getting that out of HL1606's though
+  _spcr = SPCR;
   SPCR = _BV(SPE) | _BV(MSTR);   // enable SPI master mode
   setSPIdivider(SPIspeedDiv);          // SPI clock is FCPU/32 = 500 Khz for most arduinos
   

--- a/HL1606stripPWM.h
+++ b/HL1606stripPWM.h
@@ -37,6 +37,8 @@
 
 class HL1606stripPWM {
  private:
+  uint8_t _spcr;
+
   // How many bits of color per LED for PWM?
   // if its set to 2 bits/LED that means 6 bit color (since there are 3 LEDs)
   // if its set to 3 bits/LED that equals 9 bit color
@@ -65,6 +67,7 @@ class HL1606stripPWM {
  public:
   HL1606stripPWM(uint8_t nLEDs, uint8_t latch);
   void begin(void);
+  void end(void);
   void setLEDcolorPWM(uint8_t n, uint8_t r, uint8_t g, uint8_t b);
   uint8_t numLEDs(void);
 


### PR DESCRIPTION
Stop timer and restore SPCR register.
Now, it is possible to use correctly HL1606strip after HL1606stripPWM.
